### PR TITLE
実行時のサーバ名/ホスト名変更

### DIFF
--- a/sakuracloud/step_create_server.go
+++ b/sakuracloud/step_create_server.go
@@ -96,7 +96,7 @@ func (s *stepCreateServer) createServerBuilder(state multistep.StateBag) serverB
 	client := state.Get("client").(*api.Client)
 	c := state.Get("config").(Config)
 
-	serverName := "packer_builder_sakuracloud"
+	serverName := "packer-builder-sakuracloud"
 
 	switch c.OSType {
 	case "iso":


### PR DESCRIPTION
To fix #17 

現在はアンダーバーが含まれるためディスクの修正APIを呼び出す際にバリデーションエラーとなる。
このため、アンダーバーを含まない名前に変更する。