### PR TITLE
Add "custom" to valid os types

### DIFF
--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -265,7 +265,7 @@ func validateConfig(c *Config, errs *packer.MultiError) *packer.MultiError {
 }
 
 func listOSType() []string {
-	return append(ostype.OSTypeShortNames, constants.TargetOSISO)
+	return append(ostype.OSTypeShortNames, constants.TargetOSCustom, constants.TargetOSISO)
 }
 
 func listDiskConnection() []string {

--- a/sakuracloud/constants/target_os.go
+++ b/sakuracloud/constants/target_os.go
@@ -1,3 +1,6 @@
 package constants
 
-const TargetOSISO string = "iso"
+const (
+	TargetOSCustom string = "custom"
+	TargetOSISO    string = "iso"
+)


### PR DESCRIPTION
## WHAT

Add `custom` to valid os type list explicitly to build archive from existing archive.

```sh-session
$ grep os_type template.json
    "os_type": "custom",
$ packer build template.json
sakuracloud output will be in this color.

==> sakuracloud: --> step: CreateSSHKey start
==> sakuracloud:        Creating temporary SSH key for instance...
...
```

I added `custom` to this plugin only instead of libsacloud because it seems that OS type `custom` is used in Packer plugin only as well as OS type `iso`.

## WHY

When we specify `"os_type": "custom"` in Packer template, Packer with packer-builder-sakuracloud v0.2.0 returns the following error.

```sh-session
$ packer build template.json
sakuracloud output will be in this color.

1 error(s) occurred:

* os_type is invalid
```

OS type `custom` is not listed in [`OSTypeShortNames` in libsacloud](https://github.com/sacloud/libsacloud/blob/108b1efe4b4d106fee6760bdf1847c4f92e1a92e/sacloud/ostype/archive_ostype.go#L60-L69). Therefore packer-builder-sakuracloud rejects it.