### PR TITLE
Transfer archive to other zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Packer 1.5以降で利用できるHCLテンプレートに対応しています�
 ```hcl
 source "sakuracloud" "example" {
   zone = "is1b"
+  zones = ["is1a", "is1b", "tk1a", "tk1v"]
 
   os_type   = "centos7"
   password  = "TestUserPassword01"
@@ -157,7 +158,7 @@ jsonファイルで指定できるオプションの一覧は以下の通りで�
 | 値                              | 説明                                                    |
 |-- -------------------------    | ------------------                                  --|
 | `centos`                       | CentOS(最新安定板)                                         |
-| `centos7`                      | CentOS 8                                              |
+| `centos8`                      | CentOS 8                                              |
 | `centos7`                      | CentOS 7                                              |
 | `centos6`                      | CentOS 6                                              |
 | `ubuntu`                       | Ubuntu(最新安定板)                                         |
@@ -192,6 +193,12 @@ jsonファイルで指定できるオプションの一覧は以下の通りで�
 `iso`の場合の詳細は[ISOイメージ関連項目の指定について](#isoイメージ関連項目の指定について)を参照ください。
 
 ### オプション項目
+
+- `zones`: 作成したアーカイブを転送する宛先ゾーン名のリスト。以下のいずれかの値を指定(複数指定可)
+    - `is1a`: 石狩第1ゾーン
+    - `is1b`: 石狩第2ゾーン
+    - `tk1a`: 東京第1ゾーン
+    - `tk1v`: サンドボックス
 
 - `user_name`(string): SSH/WinRM接続時のユーザー名
 

--- a/examples/centos8/template.pkr.hcl
+++ b/examples/centos8/template.pkr.hcl
@@ -1,0 +1,27 @@
+source "sakuracloud" "example" {
+  zone  = "is1b"
+  zones = ["is1a", "is1b", "tk1a", "tk1v"]
+
+  os_type   = "centos8"
+  password  = "TestUserPassword01"
+  disk_size = 20
+  disk_plan = "ssd"
+
+  core        = 2
+  memory_size = 4
+
+  archive_name        = "packer-example-centos"
+  archive_description = "description of archive"
+}
+
+build {
+  sources = [
+    "source.sakuracloud.example"
+  ]
+  provisioner "shell" {
+    inline = [
+      "echo 'hello!'",
+    ]
+  }
+}
+

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
-	github.com/sacloud/libsacloud/v2 v2.1.8
+	github.com/sacloud/libsacloud/v2 v2.3.0
 	github.com/stretchr/testify v1.4.0
 	github.com/zclconf/go-cty v1.2.1
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 h1:7YvPJVmEeFHR1T
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht3QdNJ13Stey0hR6asicabuEqU=
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
-github.com/sacloud/libsacloud/v2 v2.1.8 h1:6jkX+RDkRXZ6WUxWrdedB6DSFNLxiD+i9HQLKJfLig4=
-github.com/sacloud/libsacloud/v2 v2.1.8/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
+github.com/sacloud/libsacloud/v2 v2.3.0 h1:ryRa9U87ZwhcCqWhqww8d1klPdg5J2iAfAV4VTGt0zM=
+github.com/sacloud/libsacloud/v2 v2.3.0/go.mod h1:BG2crADa3HJrADiZK2zK1/UxsVUtWSy6q7nd6YqleD4=
 github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/iaas/archive.go
+++ b/iaas/archive.go
@@ -6,16 +6,16 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	archiveBuilder "github.com/sacloud/libsacloud/v2/utils/builder/archive"
 	"github.com/sacloud/libsacloud/v2/utils/query"
 	"github.com/sacloud/libsacloud/v2/utils/setup"
 )
 
 // Archive is responsible for API calls of archive handling
 type Archive interface {
-	//Read(ctx context.Context, zone string, id types.ID) (*sacloud.Archive, error)
-	//Create(ctx context.Context, zone string, param *sacloud.ArchiveCreateRequest) (*sacloud.Archive, error)
 	Delete(ctx context.Context, id types.ID) error
 	Create(ctx context.Context, req *CreateArchiveRequest) (*sacloud.Archive, error)
+	Transfer(ctx context.Context, zone string, req *TransferArchiveRequest) (*sacloud.Archive, error)
 }
 
 type archiveClient struct {
@@ -38,18 +38,25 @@ func (c *archiveClient) Delete(ctx context.Context, id types.ID) error {
 	return c.archiveOp.Delete(ctx, c.zone, id)
 }
 
+func (c *archiveClient) tagsFromAncestors(ctx context.Context, currentTags types.Tags, id types.ID) (types.Tags, error) {
+	if len(currentTags) != 0 {
+		return currentTags, nil
+	}
+	parentArchiveID, err := query.GetPublicArchiveIDFromAncestors(ctx, c.zone, query.NewArchiveSourceReader(c.caller), id)
+	if err != nil {
+		return nil, err
+	}
+	parentArchive, err := c.archiveOp.Read(ctx, c.zone, parentArchiveID)
+	if err != nil {
+		return nil, err
+	}
+	return parentArchive.Tags, nil
+}
+
 func (c *archiveClient) Create(ctx context.Context, req *CreateArchiveRequest) (*sacloud.Archive, error) {
-	tags := req.Tags
-	if len(tags) == 0 {
-		parentArchiveID, err := query.GetPublicArchiveIDFromAncestors(ctx, c.zone, query.NewArchiveSourceReader(c.caller), req.DiskID)
-		if err != nil {
-			return nil, err
-		}
-		parentArchive, err := c.archiveOp.Read(ctx, c.zone, parentArchiveID)
-		if err != nil {
-			return nil, err
-		}
-		tags = parentArchive.Tags
+	tags, err := c.tagsFromAncestors(ctx, req.Tags, req.DiskID)
+	if err != nil {
+		return nil, err
 	}
 
 	archiveBuilder := &setup.RetryableSetup{
@@ -83,4 +90,31 @@ type CreateArchiveRequest struct {
 	Name        string
 	Tags        types.Tags
 	Description string
+}
+
+// TransferArchiveRequest is a parameter of creating SakuraCloud Archive
+type TransferArchiveRequest struct {
+	Name              string
+	Tags              types.Tags
+	Description       string
+	SourceArchiveID   types.ID
+	SourceArchiveZone string
+}
+
+func (c *archiveClient) Transfer(ctx context.Context, zone string, req *TransferArchiveRequest) (*sacloud.Archive, error) {
+	tags, err := c.tagsFromAncestors(ctx, req.Tags, req.SourceArchiveID)
+	if err != nil {
+		return nil, err
+	}
+
+	builder := &archiveBuilder.TransferArchiveBuilder{
+		Name:              req.Name,
+		Description:       req.Description,
+		Tags:              tags,
+		SourceArchiveID:   req.SourceArchiveID,
+		SourceArchiveZone: req.SourceArchiveZone,
+		Client:            archiveBuilder.NewAPIClient(c.caller),
+	}
+
+	return builder.Build(ctx, zone)
 }

--- a/sakuracloud/artifact.go
+++ b/sakuracloud/artifact.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/packer-builder-sakuracloud/iaas"
@@ -17,6 +18,9 @@ type Artifact struct {
 
 	// archiveID is the ID of the image
 	archiveID types.ID
+
+	transferredIDs   []types.ID
+	transferredZones []string
 
 	// client is the SakuraCloud API client
 	client iaas.Archive
@@ -41,7 +45,15 @@ func (a *Artifact) Id() string {
 
 // String returns human-readable output that describes the artifact created.
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A archive was created: %s (ID: %q)", a.archiveName, a.archiveID)
+	var transferred []string
+	for i := range a.transferredIDs {
+		transferred = append(transferred, fmt.Sprintf("%q in %s", a.transferredIDs[i], a.transferredZones[i]))
+	}
+	strTrans := ""
+	if len(transferred) > 0 {
+		strTrans = fmt.Sprintf("transferred: %s", strings.Join(transferred, ", "))
+	}
+	return fmt.Sprintf("A archive was created: %s (ID: %q) transferred: %s", a.archiveName, a.archiveID, strTrans)
 }
 
 // State allows the caller to ask for builder specific state information

--- a/sakuracloud/builder.go
+++ b/sakuracloud/builder.go
@@ -138,6 +138,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&stepCreateArchive{
 			Debug: b.config.PackerDebug,
 		},
+		&stepTransferArchive{
+			Debug: b.config.PackerDebug,
+		},
 	}
 
 	if b.config.OSType == constants.TargetOSISO {
@@ -167,9 +170,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	}
 
 	artifact := &Artifact{
-		archiveID:   state.Get("archive_id").(types.ID),
-		archiveName: state.Get("archive_name").(string),
-		client:      client.Archive,
+		archiveID:        state.Get("archive_id").(types.ID),
+		archiveName:      state.Get("archive_name").(string),
+		transferredIDs:   state.Get("transferred_ids").([]types.ID),
+		transferredZones: state.Get("transferred_zones").([]string),
+		client:           client.Archive,
 	}
 
 	return artifact, nil

--- a/sakuracloud/config.go
+++ b/sakuracloud/config.go
@@ -37,9 +37,10 @@ type Config struct {
 	Comm                communicator.Config `mapstructure:",squash"`
 
 	// for API Auth
-	AccessToken       string `mapstructure:"access_token"`
-	AccessTokenSecret string `mapstructure:"access_token_secret"`
-	Zone              string `mapstructure:"zone"`
+	AccessToken       string   `mapstructure:"access_token"`
+	AccessTokenSecret string   `mapstructure:"access_token_secret"`
+	Zone              string   `mapstructure:"zone"`
+	Zones             []string `mapstructure:"zones"`
 
 	// for Communication
 	UserName      string `mapstructure:"user_name"`
@@ -133,6 +134,10 @@ func setDefaultConfig(c *Config) {
 	}
 	if c.AccessTokenSecret == "" {
 		c.AccessTokenSecret = os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+	}
+
+	if len(c.Zones) == 0 {
+		c.Zones = []string{c.Zone}
 	}
 
 	if c.DiskConnection == "" {

--- a/sakuracloud/config.hcl2spec.go
+++ b/sakuracloud/config.hcl2spec.go
@@ -60,6 +60,7 @@ type FlatConfig struct {
 	AccessToken               *string           `mapstructure:"access_token" cty:"access_token"`
 	AccessTokenSecret         *string           `mapstructure:"access_token_secret" cty:"access_token_secret"`
 	Zone                      *string           `mapstructure:"zone" cty:"zone"`
+	Zones                     []string          `mapstructure:"zones" cty:"zones"`
 	UserName                  *string           `mapstructure:"user_name" cty:"user_name"`
 	Password                  *string           `mapstructure:"password" cty:"password"`
 	UseUSKeyboard             *bool             `mapstructure:"us_keyboard" cty:"us_keyboard"`
@@ -154,6 +155,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"access_token":                 &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"access_token_secret":          &hcldec.AttrSpec{Name: "access_token_secret", Type: cty.String, Required: false},
 		"zone":                         &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
+		"zones":                        &hcldec.AttrSpec{Name: "zones", Type: cty.List(cty.String), Required: false},
 		"user_name":                    &hcldec.AttrSpec{Name: "user_name", Type: cty.String, Required: false},
 		"password":                     &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"us_keyboard":                  &hcldec.AttrSpec{Name: "us_keyboard", Type: cty.Bool, Required: false},

--- a/sakuracloud/step_transfer_archive.go
+++ b/sakuracloud/step_transfer_archive.go
@@ -1,0 +1,77 @@
+package sakuracloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/packer-builder-sakuracloud/iaas"
+)
+
+type stepTransferArchive struct {
+	Debug bool
+}
+
+func (s *stepTransferArchive) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	state.Put("transferred_ids", []types.ID{})
+	state.Put("transferred_zones", []string{})
+
+	c := state.Get("config").(Config)
+	if len(c.Zones) == 0 {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+	stepStartMsg(ui, s.Debug, "TransferArchive")
+	ui.Say("\tTransferring archive to other zones...")
+
+	if err := s.transferArchives(ctx, state); err != nil {
+		err := fmt.Errorf("Error creating archive: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	stepEndMsg(ui, s.Debug, "TransferArchive")
+	return multistep.ActionContinue
+}
+
+func (s *stepTransferArchive) transferArchives(ctx context.Context, state multistep.StateBag) error {
+	ui := state.Get("ui").(packer.Ui)
+	archiveClient := state.Get("iaasClient").(*iaas.Client).Archive
+	c := state.Get("config").(Config)
+	archiveID := state.Get("archive_id").(types.ID)
+
+	var transferredIDs []types.ID
+	var transferredZones []string
+
+	// SAKURA Cloud API probably doesn't support multiple Transfer API calling, so we call Transfer API synchronously.
+	for _, zone := range c.Zones {
+		if c.Zone == zone {
+			continue
+		}
+		archive, err := archiveClient.Transfer(ctx, zone, &iaas.TransferArchiveRequest{
+			Name:              c.ArchiveName,
+			Tags:              c.ArchiveTags,
+			Description:       c.ArchiveDescription,
+			SourceArchiveID:   archiveID,
+			SourceArchiveZone: c.Zone,
+		})
+		if err != nil {
+			return err
+		}
+		ui.Say(fmt.Sprintf("\tArchive[%s:%s] is transferred from [%s:%s]", zone, archive.ID.String(), c.Zone, archiveID.String()))
+		transferredIDs = append(transferredIDs, archive.ID)
+		transferredZones = append(transferredZones, zone)
+	}
+
+	state.Put("transferred_ids", transferredIDs)
+	state.Put("transferred_zones", transferredZones)
+	return nil
+}
+
+func (s *stepTransferArchive) Cleanup(state multistep.StateBag) {
+	// no cleanup
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/customize_envelope.go
@@ -223,3 +223,33 @@ func (s mobileGatewayFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	tmp.Filter[search.Key("Class")] = "mobilegateway"
 	return json.Marshal(tmp)
 }
+
+/*
+ * for Shared Archive
+ */
+
+func (s archiveShareRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias archiveShareRequestEnvelope
+	tmp := alias(s)
+	tmp.Shared = true
+	return json.Marshal(tmp)
+}
+
+// UnmarshalJSON APIからの戻り値でレスポンスボディ直下にデータを持つことへの対応
+func (s *archiveShareResponseEnvelope) UnmarshalJSON(data []byte) error {
+	type alias archiveShareResponseEnvelope
+
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	var nakedData naked.ArchiveShareInfo
+	if err := json.Unmarshal(data, &nakedData); err != nil {
+		return err
+	}
+	tmp.ArchiveShareInfo = &nakedData
+
+	*s = archiveShareResponseEnvelope(tmp)
+	return nil
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_archive.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_archive.go
@@ -159,3 +159,80 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 	putArchive(zone, value)
 	return nil
 }
+
+// Share is fake implementation
+func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	value.SetAvailability(types.Availabilities.Uploading)
+	putArchive(zone, value)
+
+	return &sacloud.ArchiveShareInfo{
+		SharedKey: types.ArchiveShareKey(fmt.Sprintf("%s:%s:%s", zone, id.String(), "xxx")),
+	}, nil
+}
+
+// CreateFromShared is fake implementation
+func (o *ArchiveOp) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *sacloud.ArchiveCreateRequestFromShared) (*sacloud.Archive, error) {
+	result := &sacloud.Archive{}
+
+	var destZone string
+	for name, id := range zoneIDs {
+		if id == zoneID {
+			destZone = name
+			break
+		}
+	}
+
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt, fillScope)
+
+	result.DisplayOrder = int64(random(100))
+	result.Availability = types.Availabilities.Transferring
+	result.DiskPlanID = types.DiskPlans.HDD
+	result.DiskPlanName = "標準プラン"
+	result.DiskPlanStorageClass = "iscsi9999"
+
+	putArchive(destZone, result)
+
+	id := result.ID
+	startDiskCopy(o.key, destZone, func() (interface{}, error) {
+		return o.Read(context.Background(), destZone, id)
+	})
+
+	return result, nil
+}
+
+// Transfer is fake implementation
+func (o *ArchiveOp) Transfer(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *sacloud.ArchiveTransferRequest) (*sacloud.Archive, error) {
+	result := &sacloud.Archive{}
+
+	var destZone string
+	for name, id := range zoneIDs {
+		if id == destZoneID {
+			destZone = name
+			break
+		}
+	}
+
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt, fillScope)
+
+	result.DisplayOrder = int64(random(100))
+	result.Availability = types.Availabilities.Transferring
+	result.DiskPlanID = types.DiskPlans.HDD
+	result.DiskPlanName = "標準プラン"
+	result.DiskPlanStorageClass = "iscsi9999"
+
+	putArchive(destZone, result)
+
+	id := result.ID
+	startDiskCopy(o.key, destZone, func() (interface{}, error) {
+		return o.Read(context.Background(), destZone, id)
+	})
+
+	return result, nil
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/archive.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/archive.go
@@ -22,27 +22,28 @@ import (
 
 // Archive アーカイブ
 type Archive struct {
-	ID              types.ID            `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
-	Name            string              `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
-	Description     string              `yaml:"description"`
-	Tags            types.Tags          `yaml:"tags"`
-	Icon            *Icon               `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
-	CreatedAt       *time.Time          `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
-	ModifiedAt      *time.Time          `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
-	Availability    types.EAvailability `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
-	DisplayOrder    int                 `json:",omitempty" yaml:"display_order,omitempty" structs:",omitempty"`
-	ServiceClass    string              `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
-	SizeMB          int                 `json:",omitempty" yaml:"size_mb,omitempty" structs:",omitempty"`
-	MigratedMB      int                 `json:",omitempty" yaml:"migrated_mb,omitempty" structs:",omitempty"`
-	JobStatus       *MigrationJobStatus `json:",omitempty" yaml:"job_status,omitempty" structs:",omitempty"`
-	Plan            *DiskPlan           `json:",omitempty" yaml:"plan,omitempty" structs:",omitempty"`
-	SourceDisk      *Disk               `json:",omitempty" yaml:"source_disk,omitempty" structs:",omitempty"`
-	SourceArchive   *Archive            `json:",omitempty" yaml:"source_archive,omitempty" structs:",omitempty"`
-	BundleInfo      *BundleInfo         `json:",omitempty" yaml:"bundle_info,omitempty" structs:",omitempty"`
-	Storage         *Storage            `json:",omitempty" yaml:"storage,omitempty" structs:",omitempty"`
-	Scope           types.EScope        `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
-	OriginalArchive *OriginalArchive    `json:",omitempty" yaml:"original_archive,omitempty" structs:",omitempty"`
-	SourceInfo      *SourceArchive      `json:",omitempty" yaml:"source_info,omitempty" structs:",omitempty"`
+	ID              types.ID              `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name            string                `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description     string                `yaml:"description"`
+	Tags            types.Tags            `yaml:"tags"`
+	Icon            *Icon                 `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt       *time.Time            `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt      *time.Time            `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Availability    types.EAvailability   `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
+	DisplayOrder    int                   `json:",omitempty" yaml:"display_order,omitempty" structs:",omitempty"`
+	ServiceClass    string                `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
+	SizeMB          int                   `json:",omitempty" yaml:"size_mb,omitempty" structs:",omitempty"`
+	MigratedMB      int                   `json:",omitempty" yaml:"migrated_mb,omitempty" structs:",omitempty"`
+	JobStatus       *MigrationJobStatus   `json:",omitempty" yaml:"job_status,omitempty" structs:",omitempty"`
+	Plan            *DiskPlan             `json:",omitempty" yaml:"plan,omitempty" structs:",omitempty"`
+	SourceDisk      *Disk                 `json:",omitempty" yaml:"source_disk,omitempty" structs:",omitempty"`
+	SourceArchive   *Archive              `json:",omitempty" yaml:"source_archive,omitempty" structs:",omitempty"`
+	BundleInfo      *BundleInfo           `json:",omitempty" yaml:"bundle_info,omitempty" structs:",omitempty"`
+	Storage         *Storage              `json:",omitempty" yaml:"storage,omitempty" structs:",omitempty"`
+	Scope           types.EScope          `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
+	OriginalArchive *OriginalArchive      `json:",omitempty" yaml:"original_archive,omitempty" structs:",omitempty"`
+	SourceInfo      *SourceArchive        `json:",omitempty" yaml:"source_info,omitempty" structs:",omitempty"`
+	SourceSharedKey types.ArchiveShareKey `json:",omitempty" yaml:"source_shared_key,omitempty" structs:",omitempty"`
 }
 
 // SourceArchive 他ゾーンから転送したアーカイブの情報
@@ -65,4 +66,14 @@ type SourceArchiveInfo struct {
 // OriginalArchive オリジナルアーカイブ
 type OriginalArchive struct {
 	ID types.ID `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+}
+
+// SharedArchiveCreateRequest 共有アーカイブ作成リクエスト
+type SharedArchiveCreateRequest struct {
+	Shared bool `yaml:"shared"`
+}
+
+// ArchiveShareInfo 共有アーカイブ作成レスポンス
+type ArchiveShareInfo struct {
+	SharedKey types.ArchiveShareKey `yaml:"shared_key"`
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/trace/zz_api_tracer.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/trace/zz_api_tracer.go
@@ -440,6 +440,113 @@ func (t *ArchiveTracer) CloseFTP(ctx context.Context, zone string, id types.ID) 
 	return err
 }
 
+// Share is API call with trace log
+func (t *ArchiveTracer) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
+	log.Println("[TRACE] ArchiveAPI.Share start")
+	targetArguments := struct {
+		Argzone string
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.Share end")
+	}()
+
+	resultArchiveShareInfo, err := t.Internal.Share(ctx, zone, id)
+	targetResults := struct {
+		ArchiveShareInfo *sacloud.ArchiveShareInfo
+		Error            error
+	}{
+		ArchiveShareInfo: resultArchiveShareInfo,
+		Error:            err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchiveShareInfo, err
+}
+
+// CreateFromShared is API call with trace log
+func (t *ArchiveTracer) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *sacloud.ArchiveCreateRequestFromShared) (*sacloud.Archive, error) {
+	log.Println("[TRACE] ArchiveAPI.CreateFromShared start")
+	targetArguments := struct {
+		Argzone            string
+		ArgsourceArchiveID types.ID                                `json:"sourceArchiveID"`
+		ArgdestZoneID      types.ID                                `json:"destZoneID"`
+		Argparam           *sacloud.ArchiveCreateRequestFromShared `json:"param"`
+	}{
+		Argzone:            zone,
+		ArgsourceArchiveID: sourceArchiveID,
+		ArgdestZoneID:      destZoneID,
+		Argparam:           param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.CreateFromShared end")
+	}()
+
+	resultArchive, err := t.Internal.CreateFromShared(ctx, zone, sourceArchiveID, destZoneID, param)
+	targetResults := struct {
+		Archive *sacloud.Archive
+		Error   error
+	}{
+		Archive: resultArchive,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchive, err
+}
+
+// Transfer is API call with trace log
+func (t *ArchiveTracer) Transfer(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *sacloud.ArchiveTransferRequest) (*sacloud.Archive, error) {
+	log.Println("[TRACE] ArchiveAPI.Transfer start")
+	targetArguments := struct {
+		Argzone            string
+		ArgsourceArchiveID types.ID                        `json:"sourceArchiveID"`
+		ArgdestZoneID      types.ID                        `json:"destZoneID"`
+		Argparam           *sacloud.ArchiveTransferRequest `json:"param"`
+	}{
+		Argzone:            zone,
+		ArgsourceArchiveID: sourceArchiveID,
+		ArgdestZoneID:      destZoneID,
+		Argparam:           param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.Transfer end")
+	}()
+
+	resultArchive, err := t.Internal.Transfer(ctx, zone, sourceArchiveID, destZoneID, param)
+	targetResults := struct {
+		Archive *sacloud.Archive
+		Error   error
+	}{
+		Archive: resultArchive,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchive, err
+}
+
 /*************************************************
 * AuthStatusTracer
 *************************************************/

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/archive_share_key.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/archive_share_key.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "strings"
+
+// ArchiveShareKey アーカイブ共有キー
+type ArchiveShareKey string
+
+// ArchiveShareKeyDelimiter アーカイブ共有キーのデリミタ
+const ArchiveShareKeyDelimiter = ":"
+
+// String ArchiveShareKey全体を表す文字列
+func (key ArchiveShareKey) String() string {
+	return string(key)
+}
+
+// Zone キーに含まれるゾーン名
+func (key ArchiveShareKey) Zone() string {
+	tokens := key.tokens()
+	if len(tokens) > 0 {
+		return tokens[0]
+	}
+	return ""
+}
+
+// SourceArchiveID 共有元となるアーカイブのID
+func (key ArchiveShareKey) SourceArchiveID() ID {
+	tokens := key.tokens()
+	if len(tokens) > 1 {
+		return StringID(tokens[1])
+	}
+	return ID(0)
+}
+
+// Token 認証キー本体
+func (key ArchiveShareKey) Token() string {
+	tokens := key.tokens()
+	if len(tokens) > 2 {
+		return tokens[2]
+	}
+	return ""
+}
+
+// ValidFormat 有効なキーフォーマットか
+func (key ArchiveShareKey) ValidFormat() bool {
+	return len(key.tokens()) == 3
+}
+
+func (key ArchiveShareKey) tokens() []string {
+	return strings.Split(key.String(), ArchiveShareKeyDelimiter)
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/database_version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/types/database_version.go
@@ -42,8 +42,8 @@ type RDBMSVersion struct {
 var RDBMSVersions = map[RDBMSType]*RDBMSVersion{
 	RDBMSTypesMariaDB: {
 		Name:     "MariaDB",
-		Version:  "10.3",
-		Revision: "10.3.15",
+		Version:  "10.4",
+		Revision: "",
 	},
 	RDBMSTypesPostgreSQL: {
 		Name:     "postgres",

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_ops.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_ops.go
@@ -668,6 +668,121 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 	return nil
 }
 
+// Share is API call
+func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*ArchiveShareInfo, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/ftp", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformShareArgs(id)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformShareResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ArchiveShareInfo, nil
+}
+
+// CreateFromShared is API call
+func (o *ArchiveOp) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveCreateRequestFromShared) (*Archive, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":         SakuraCloudAPIRoot,
+		"pathSuffix":      o.PathSuffix,
+		"pathName":        o.PathName,
+		"zone":            zone,
+		"sourceArchiveID": sourceArchiveID,
+		"destZoneID":      destZoneID,
+		"param":           param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.sourceArchiveID}}/to/zone/{{.destZoneID}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformCreateFromSharedArgs(sourceArchiveID, destZoneID, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformCreateFromSharedResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Archive, nil
+}
+
+// Transfer is API call
+func (o *ArchiveOp) Transfer(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveTransferRequest) (*Archive, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":         SakuraCloudAPIRoot,
+		"pathSuffix":      o.PathSuffix,
+		"pathName":        o.PathName,
+		"zone":            zone,
+		"sourceArchiveID": sourceArchiveID,
+		"destZoneID":      destZoneID,
+		"param":           param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.sourceArchiveID}}/to/zone/{{.destZoneID}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformTransferArgs(sourceArchiveID, destZoneID, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformTransferResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Archive, nil
+}
+
 /*************************************************
 * AuthStatusOp
 *************************************************/

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_transformers.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_api_transformers.go
@@ -224,6 +224,144 @@ func (o *ArchiveOp) transformOpenFTPResults(data []byte) (*archiveOpenFTPResult,
 	return results, nil
 }
 
+func (o *ArchiveOp) transformShareArgs(id types.ID) (*archiveShareRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+	}{
+		Arg0: arg0,
+	}
+
+	v := &archiveShareRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformShareResults(data []byte) (*archiveShareResult, error) {
+	nakedResponse := &archiveShareResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archiveShareResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *ArchiveOp) transformCreateFromSharedArgs(sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveCreateRequestFromShared) (*archiveCreateFromSharedRequestEnvelope, error) {
+	if sourceArchiveID == types.ID(int64(0)) {
+		sourceArchiveID = types.ID(int64(0))
+	}
+	var arg0 interface{} = sourceArchiveID
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if destZoneID == types.ID(int64(0)) {
+		destZoneID = types.ID(int64(0))
+	}
+	var arg1 interface{} = destZoneID
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ArchiveCreateRequestFromShared{}
+	}
+	var arg2 interface{} = param
+	if v, ok := arg2.(argumentDefaulter); ok {
+		arg2 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{}
+		Arg2 interface{} `mapconv:"Archive,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+		Arg2: arg2,
+	}
+
+	v := &archiveCreateFromSharedRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformCreateFromSharedResults(data []byte) (*archiveCreateFromSharedResult, error) {
+	nakedResponse := &archiveCreateFromSharedResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archiveCreateFromSharedResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *ArchiveOp) transformTransferArgs(sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveTransferRequest) (*archiveTransferRequestEnvelope, error) {
+	if sourceArchiveID == types.ID(int64(0)) {
+		sourceArchiveID = types.ID(int64(0))
+	}
+	var arg0 interface{} = sourceArchiveID
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if destZoneID == types.ID(int64(0)) {
+		destZoneID = types.ID(int64(0))
+	}
+	var arg1 interface{} = destZoneID
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ArchiveTransferRequest{}
+	}
+	var arg2 interface{} = param
+	if v, ok := arg2.(argumentDefaulter); ok {
+		arg2 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{}
+		Arg2 interface{} `mapconv:"Archive,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+		Arg2: arg2,
+	}
+
+	v := &archiveTransferRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformTransferResults(data []byte) (*archiveTransferResult, error) {
+	nakedResponse := &archiveTransferResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archiveTransferResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *AuthStatusOp) transformReadResults(data []byte) (*authStatusReadResult, error) {
 	nakedResponse := &authStatusReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_apis.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_apis.go
@@ -36,6 +36,9 @@ type ArchiveAPI interface {
 	Delete(ctx context.Context, zone string, id types.ID) error
 	OpenFTP(ctx context.Context, zone string, id types.ID, openOption *OpenFTPRequest) (*FTPServer, error)
 	CloseFTP(ctx context.Context, zone string, id types.ID) error
+	Share(ctx context.Context, zone string, id types.ID) (*ArchiveShareInfo, error)
+	CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveCreateRequestFromShared) (*Archive, error)
+	Transfer(ctx context.Context, zone string, sourceArchiveID types.ID, destZoneID types.ID, param *ArchiveTransferRequest) (*Archive, error)
 }
 
 /*************************************************

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_envelopes.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_envelopes.go
@@ -104,6 +104,45 @@ type archiveOpenFTPResponseEnvelope struct {
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
+// archiveShareRequestEnvelope is envelop of API request
+type archiveShareRequestEnvelope struct {
+	Shared bool `json:",omitempty"`
+}
+
+// archiveShareResponseEnvelope is envelop of API response
+type archiveShareResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	ArchiveShareInfo *naked.ArchiveShareInfo `json:",omitempty"`
+}
+
+// archiveCreateFromSharedRequestEnvelope is envelop of API request
+type archiveCreateFromSharedRequestEnvelope struct {
+	Archive *naked.Archive `json:",omitempty"`
+}
+
+// archiveCreateFromSharedResponseEnvelope is envelop of API response
+type archiveCreateFromSharedResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Archive *naked.Archive `json:",omitempty"`
+}
+
+// archiveTransferRequestEnvelope is envelop of API request
+type archiveTransferRequestEnvelope struct {
+	Archive *naked.Archive `json:",omitempty"`
+}
+
+// archiveTransferResponseEnvelope is envelop of API response
+type archiveTransferResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Archive *naked.Archive `json:",omitempty"`
+}
+
 // authStatusReadResponseEnvelope is envelop of API response
 type authStatusReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -1176,6 +1176,259 @@ func (o *OpenFTPRequest) SetChangePassword(v bool) {
 }
 
 /*************************************************
+* ArchiveShareInfo
+*************************************************/
+
+// ArchiveShareInfo represents API parameter/response structure
+type ArchiveShareInfo struct {
+	SharedKey types.ArchiveShareKey
+}
+
+// Validate validates by field tags
+func (o *ArchiveShareInfo) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchiveShareInfo) setDefaults() interface{} {
+	return &struct {
+		SharedKey types.ArchiveShareKey
+	}{
+		SharedKey: o.GetSharedKey(),
+	}
+}
+
+// GetSharedKey returns value of SharedKey
+func (o *ArchiveShareInfo) GetSharedKey() types.ArchiveShareKey {
+	return o.SharedKey
+}
+
+// SetSharedKey sets value to SharedKey
+func (o *ArchiveShareInfo) SetSharedKey(v types.ArchiveShareKey) {
+	o.SharedKey = v
+}
+
+/*************************************************
+* ArchiveCreateRequestFromShared
+*************************************************/
+
+// ArchiveCreateRequestFromShared represents API parameter/response structure
+type ArchiveCreateRequestFromShared struct {
+	Name            string `validate:"required"`
+	Description     string `validate:"min=0,max=512"`
+	Tags            types.Tags
+	IconID          types.ID `mapconv:"Icon.ID"`
+	SourceSharedKey types.ArchiveShareKey
+}
+
+// Validate validates by field tags
+func (o *ArchiveCreateRequestFromShared) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchiveCreateRequestFromShared) setDefaults() interface{} {
+	return &struct {
+		Name            string `validate:"required"`
+		Description     string `validate:"min=0,max=512"`
+		Tags            types.Tags
+		IconID          types.ID `mapconv:"Icon.ID"`
+		SourceSharedKey types.ArchiveShareKey
+	}{
+		Name:            o.GetName(),
+		Description:     o.GetDescription(),
+		Tags:            o.GetTags(),
+		IconID:          o.GetIconID(),
+		SourceSharedKey: o.GetSourceSharedKey(),
+	}
+}
+
+// GetName returns value of Name
+func (o *ArchiveCreateRequestFromShared) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ArchiveCreateRequestFromShared) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ArchiveCreateRequestFromShared) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ArchiveCreateRequestFromShared) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *ArchiveCreateRequestFromShared) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ArchiveCreateRequestFromShared) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ArchiveCreateRequestFromShared) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ArchiveCreateRequestFromShared) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ArchiveCreateRequestFromShared) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ArchiveCreateRequestFromShared) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *ArchiveCreateRequestFromShared) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ArchiveCreateRequestFromShared) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetSourceSharedKey returns value of SourceSharedKey
+func (o *ArchiveCreateRequestFromShared) GetSourceSharedKey() types.ArchiveShareKey {
+	return o.SourceSharedKey
+}
+
+// SetSourceSharedKey sets value to SourceSharedKey
+func (o *ArchiveCreateRequestFromShared) SetSourceSharedKey(v types.ArchiveShareKey) {
+	o.SourceSharedKey = v
+}
+
+/*************************************************
+* ArchiveTransferRequest
+*************************************************/
+
+// ArchiveTransferRequest represents API parameter/response structure
+type ArchiveTransferRequest struct {
+	SizeMB      int
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        types.Tags
+	IconID      types.ID `mapconv:"Icon.ID"`
+}
+
+// Validate validates by field tags
+func (o *ArchiveTransferRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchiveTransferRequest) setDefaults() interface{} {
+	return &struct {
+		SizeMB      int
+		Name        string `validate:"required"`
+		Description string `validate:"min=0,max=512"`
+		Tags        types.Tags
+		IconID      types.ID `mapconv:"Icon.ID"`
+	}{
+		SizeMB:      o.GetSizeMB(),
+		Name:        o.GetName(),
+		Description: o.GetDescription(),
+		Tags:        o.GetTags(),
+		IconID:      o.GetIconID(),
+	}
+}
+
+// GetSizeMB returns value of SizeMB
+func (o *ArchiveTransferRequest) GetSizeMB() int {
+	return o.SizeMB
+}
+
+// SetSizeMB sets value to SizeMB
+func (o *ArchiveTransferRequest) SetSizeMB(v int) {
+	o.SizeMB = v
+}
+
+// GetSizeGB .
+func (o *ArchiveTransferRequest) GetSizeGB() int {
+	return accessor.GetSizeGB(o)
+}
+
+// SetSizeGB .
+func (o *ArchiveTransferRequest) SetSizeGB(size int) {
+	accessor.SetSizeGB(o, size)
+}
+
+// GetName returns value of Name
+func (o *ArchiveTransferRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ArchiveTransferRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ArchiveTransferRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ArchiveTransferRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *ArchiveTransferRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ArchiveTransferRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ArchiveTransferRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ArchiveTransferRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ArchiveTransferRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ArchiveTransferRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *ArchiveTransferRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ArchiveTransferRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+/*************************************************
 * AuthStatus
 *************************************************/
 

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_result.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_result.go
@@ -61,6 +61,27 @@ type archiveOpenFTPResult struct {
 	FTPServer *FTPServer `json:",omitempty" mapconv:"FTPServer,omitempty,recursive"`
 }
 
+// archiveShareResult represents the Result of API
+type archiveShareResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ArchiveShareInfo *ArchiveShareInfo `json:",omitempty" mapconv:"ArchiveShareInfo,omitempty,recursive"`
+}
+
+// archiveCreateFromSharedResult represents the Result of API
+type archiveCreateFromSharedResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Archive *Archive `json:",omitempty" mapconv:"Archive,omitempty,recursive"`
+}
+
+// archiveTransferResult represents the Result of API
+type archiveTransferResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Archive *Archive `json:",omitempty" mapconv:"Archive,omitempty,recursive"`
+}
+
 // authStatusReadResult represents the Result of API
 type authStatusReadResult struct {
 	IsOk bool `json:",omitempty"` // is_ok

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/api_client.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/api_client.go
@@ -1,0 +1,31 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import "github.com/sacloud/libsacloud/v2/sacloud"
+
+// APIClient builderが利用するAPIクライアント
+type APIClient struct {
+	Archive sacloud.ArchiveAPI
+	Zone    sacloud.ZoneAPI
+}
+
+// NewAPIClient builderが利用するAPIクライアントを返す
+func NewAPIClient(caller sacloud.APICaller) *APIClient {
+	return &APIClient{
+		Archive: sacloud.NewArchiveOp(caller),
+		Zone:    sacloud.NewZoneOp(caller),
+	}
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/from_shared_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/from_shared_archive_builder.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// FromSharedArchiveBuilder 共有アーカイブからアーカイブの作成を行う
+type FromSharedArchiveBuilder struct {
+	Name            string
+	Description     string
+	Tags            types.Tags
+	IconID          types.ID
+	SourceSharedKey types.ArchiveShareKey
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *FromSharedArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":            b.Name == "",
+		"SourceSharedKey": b.SourceSharedKey == "",
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	if !b.SourceSharedKey.ValidFormat() {
+		return fmt.Errorf("archive shared key is invalid format: key:%q", b.SourceSharedKey)
+	}
+	return nil
+}
+
+// Build 共有アーカイブからアーカイブの作成を行う
+func (b *FromSharedArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	zoneID, err := query.ZoneIDFromName(ctx, b.Client.Zone, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.CreateFromShared(ctx, b.SourceSharedKey.Zone(), b.SourceSharedKey.SourceArchiveID(), zoneID,
+		&sacloud.ArchiveCreateRequestFromShared{
+			Name:            b.Name,
+			Description:     b.Description,
+			Tags:            b.Tags,
+			IconID:          b.IconID,
+			SourceSharedKey: b.SourceSharedKey,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/transfer_archive_builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/builder/archive/transfer_archive_builder.go
@@ -1,0 +1,91 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// TransferArchiveBuilder 共有アーカイブからアーカイブの作成を行う
+type TransferArchiveBuilder struct {
+	Name        string
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	SourceArchiveID   types.ID
+	SourceArchiveZone string
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *TransferArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":              b.Name == "",
+		"SourceArchiveID":   b.SourceArchiveID.IsEmpty(),
+		"SourceArchiveZone": b.SourceArchiveZone == "",
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build 他ゾーンのアーカイブからアーカイブの作成を行う
+func (b *TransferArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	zoneID, err := query.ZoneIDFromName(ctx, b.Client.Zone, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceInfo, err := b.Client.Archive.Read(ctx, b.SourceArchiveZone, b.SourceArchiveID)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.Transfer(ctx, b.SourceArchiveZone, b.SourceArchiveID, zoneID,
+		&sacloud.ArchiveTransferRequest{
+			Name:        b.Name,
+			Description: b.Description,
+			Tags:        b.Tags,
+			IconID:      b.IconID,
+			SizeMB:      sourceInfo.SizeMB,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/utils/query/archive_share_key.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/utils/query/archive_share_key.go
@@ -1,0 +1,41 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/search"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// ZoneIDFromName ゾーン名からゾーンIDを取得
+func ZoneIDFromName(ctx context.Context, zoneAPI sacloud.ZoneAPI, name string) (types.ID, error) {
+	searched, err := zoneAPI.Find(ctx, &sacloud.FindCondition{
+		Filter: search.Filter{
+			search.Key("Name"): search.ExactMatch(name),
+		},
+		Include: []string{"ID"},
+	})
+	if err != nil {
+		return types.ID(0), err
+	}
+	if searched.Count == 0 {
+		return types.ID(0), fmt.Errorf("zone %q is not found", name)
+	}
+	return searched.Zones[0].ID, nil
+}

--- a/vendor/github.com/sacloud/libsacloud/v2/version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/version.go
@@ -15,4 +15,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "2.1.8"
+const Version = "2.3.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,7 +244,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/ryanuber/go-glob
 # github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 github.com/sacloud/ftps
-# github.com/sacloud/libsacloud/v2 v2.1.8
+# github.com/sacloud/libsacloud/v2 v2.3.0
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/pkg/cidr
 github.com/sacloud/libsacloud/v2/pkg/mapconv

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -260,6 +260,7 @@ github.com/sacloud/libsacloud/v2/sacloud/search/keys
 github.com/sacloud/libsacloud/v2/sacloud/trace
 github.com/sacloud/libsacloud/v2/sacloud/types
 github.com/sacloud/libsacloud/v2/utils/builder
+github.com/sacloud/libsacloud/v2/utils/builder/archive
 github.com/sacloud/libsacloud/v2/utils/builder/disk
 github.com/sacloud/libsacloud/v2/utils/builder/server
 github.com/sacloud/libsacloud/v2/utils/power


### PR DESCRIPTION
fixes #42 

`zones`パラメータを指定することで作成したアーカイブを他ゾーンにコピー(転送)できるようにする。

```hcl
source "sakuracloud" "example" {
  zone  = "is1b"
  zones = ["is1a", "is1b", "tk1a"]

  # ...
}
```

Note: sacloud.ArchiveAPI.Transferを並列に複数呼ぶと`unexpected EOF`エラーとなる。  
このためこのPRでは各ゾーンへ順番に同期的に転送を行なうようにした。