### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2017-2021 The Usacloud Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.16 AS builder
+MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
+
+RUN set -x
+RUN apt update && apt install -y zip
+
+ADD . /go/src/github.com/sacloud/packer-builder-sakuracloud
+
+WORKDIR /go/src/github.com/sacloud/packer-builder-sakuracloud
+RUN make tools build
+# ======
+
+FROM hashicorp/packer:light
+MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
+
+COPY --from=builder /go/src/github.com/sacloud/packer-builder-sakuracloud/bin/packer-plugin-sakuracloud /bin/

--- a/Makefile
+++ b/Makefile
@@ -53,19 +53,6 @@ golangci-lint: fmt
 goimports:
 	find . -name '*.go' | grep -v vendor | xargs goimports -l -w
 
-.PHONY: docker-shell docker-test docker-testacc docker-build
-docker-shell:
-	docker-compose run --rm packer
-
-docker-test:
-	sh -c "'$(CURDIR)/scripts/build_on_docker.sh' 'test'"
-
-docker-testacc:
-	sh -c "'$(CURDIR)/scripts/build_on_docker.sh' 'testacc'"
-
-docker-build: clean 
-	sh -c "'$(CURDIR)/scripts/build_on_docker.sh' 'build-x'"
-
 .PHONY: prepare-homebrew
 prepare-homebrew:
 	rm -rf homebrew-packer-builder-sakuracloud/; \


### PR DESCRIPTION
GitHub Container Registry対応の準備としてDockerファイルを最新にする

- multi stage build
- `hashicorp/packer:light`をベースイメージに
- プラグインは`packer`と同じ階層に配置

