### PR TITLE
GitHub Container Registry

### DIFF
--- a/.github/workflows/publish_dev_docker_image.yaml
+++ b/.github/workflows/publish_dev_docker_image.yaml
@@ -1,0 +1,30 @@
+# from https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+name: Publish Docker image(latest)
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry(dev)
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/sacloud/packer:dev
+          push: true

--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -1,0 +1,35 @@
+# from https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+name: Publish Docker image
+on:
+  push:
+    tags: 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry(latest)
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/sacloud/packer
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.docker_meta.outputs.tags }},ghcr.io/sacloud/packer:latest
+          push: true


### PR DESCRIPTION
GitHub ActionsでGitHub Container Registryへのイメージ公開を行う。

- DockerHubについては引き続きAutomationBuildでイメージ公開を継続する
- 公開するイメージは3種
  - `ghcr.io/sacloud/packer:<TAG>`: タグ付きバージョン
  - `ghcr.io/sacloud/packer:latest`: 最後に公開したタグ付きバージョンのエイリアス
  - `ghcr.io/sacloud/packer:dev`: masterブランチ(マージの都度更新)

Note: このPRでのトリガーの場合、複数バージョンをサポートする場合に`latest`が最新ではなくなる可能性がある。現時点では問題ないため必要に応じて対応する。
